### PR TITLE
ci: Remove build step from PR checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -36,6 +36,3 @@ jobs:
 
       - name: Test
         run: pnpm test
-
-      - name: Build
-        run: pnpm build


### PR DESCRIPTION
## Summary
- Remove redundant build step from PR checks workflow
- Keep essential validation steps: typecheck, lint, format check, and tests

## Test plan
- [x] Verify PR checks workflow runs successfully without build step
- [x] Confirm all necessary validation steps remain in place

🤖 Generated with [Claude Code](https://claude.ai/code)